### PR TITLE
Update CherryPy requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 configobj==5.0.5
-cherrypy==3.5.0
+cherrypy==3.6.0
 #python-ldap==2.3.13
 ws4py==0.3.2
 SQLAlchemy==0.8.5


### PR DESCRIPTION
The latest version of CherryPy fixes the autoreloader error, so this updates CherryPy for new installs.
