### PR TITLE
Changing default sideboard error printing behavior

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -16,5 +16,5 @@ root = "DEBUG"
 #stream = "ext://sys.stderr"
 
 [[syslog]]
-class = "logging.handlers.SysLogHandlers"
+class = "logging.handlers.SysLogHandler"
 address = "/dev/log"


### PR DESCRIPTION
Printing to stdout can cause multiple crashes when running plug-ins in sideboard, so a better default behavior is to print to syslog instead.
