### PR TITLE
use pip to install requirements by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ data/*.db
 node_modules/
 distribute-*.tar.gz
 distribute_setup.py
+.eggs/

--- a/pavement.py
+++ b/pavement.py
@@ -74,7 +74,7 @@ def make_venv():
     develop_sideboard()
 
 def install_pip_requirements_in_dir(dir_of_requirements_txt):
-    path_to_pip = __here__ / path('env/bin/pip3')
+    path_to_pip = __here__ / path('env/bin/pip')
     sh('{pip} install -e {dir_of_requirements_txt}'
         .format(
             pip=path_to_pip,

--- a/pavement.py
+++ b/pavement.py
@@ -73,9 +73,28 @@ def make_venv():
     bootstrap_venv(__here__ / path('env'), 'sideboard')
     develop_sideboard()
 
+def install_pip_requirement(dir_of_requirements_txt):
+    path_to_pip = __here__ / path('env/bin/pip3')
+    sh('{pip} install -e {dir_of_requirements_txt}'
+        .format(
+            pip=path_to_pip,
+            dir_of_requirements_txt=dir_of_requirements_txt))
+
+@task
+def install_pip_requirements():
+    install_pip_requirement(__here__)
+    for pdir in collect_plugin_dirs():
+        install_pip_requirement(pdir)
+
+def run_setup_py(path):
+    sh('cd {path} && {python_path} {setup_path} develop'
+        .format(
+            path=path,
+            python_path=sys.executable,
+            setup_path=join(path, 'setup.py')))
+
 def develop_sideboard():
-    # TODO: this is very hard-coded and should be done better
-    sh('{python_path} setup.py develop'.format(python_path=join('env', 'bin', 'python')))
+    run_setup_py(__here__)
 
 @task
 def pull_plugins():
@@ -175,14 +194,6 @@ def create_plugin(options):
     skeleton.create_plugin(PLUGINS_DIR, plugin_name, **kwargs)
     print('{} successfully created'.format(options.create_plugin.name))
 
-@task
-def install_deps():
-    develop_sideboard()
-    for pdir in collect_plugin_dirs():
-        sh('cd {pdir} && {python_path} {setup_path} develop'
-           .format(pdir=pdir,
-                   python_path=join(__here__, 'env', 'bin', 'python'),
-                   setup_path=join(pdir, 'setup.py')))
 
 @task
 def clean():

--- a/pavement.py
+++ b/pavement.py
@@ -73,18 +73,12 @@ def make_venv():
     bootstrap_venv(__here__ / path('env'), 'sideboard')
     develop_sideboard()
 
-def install_pip_requirement(dir_of_requirements_txt):
+def install_pip_requirements_in_dir(dir_of_requirements_txt):
     path_to_pip = __here__ / path('env/bin/pip3')
     sh('{pip} install -e {dir_of_requirements_txt}'
         .format(
             pip=path_to_pip,
             dir_of_requirements_txt=dir_of_requirements_txt))
-
-@task
-def install_pip_requirements():
-    install_pip_requirement(__here__)
-    for pdir in collect_plugin_dirs():
-        install_pip_requirement(pdir)
 
 def run_setup_py(path):
     sh('cd {path} && {python_path} {setup_path} develop'
@@ -194,6 +188,11 @@ def create_plugin(options):
     skeleton.create_plugin(PLUGINS_DIR, plugin_name, **kwargs)
     print('{} successfully created'.format(options.create_plugin.name))
 
+@task
+def install_deps():
+    install_pip_requirements_in_dir(__here__)
+    for pdir in collect_plugin_dirs():
+        install_pip_requirements_in_dir(pdir)
 
 @task
 def clean():


### PR DESCRIPTION
install_deps() now uses pip to install stuff, instead of setuptools

needed for docker

removes an extra step when using puppet

@EliAndrewC need your eyes on this for merge.  afterwards I have a bunch of other PR's that change the sideboard branch back to master

This PR should be merged --first--