### PR TITLE
Make priority_plugins work regardless of setup vagaries

### DIFF
--- a/sideboard/internal/imports.py
+++ b/sideboard/internal/imports.py
@@ -11,7 +11,7 @@ plugins = {}
 def _discover_plugins():
     ordered = list(reversed(config['priority_plugins']))
     plugin_dirs = [d for d in glob(join(config['plugins_dir'], '*')) if isdir(d) and not basename(d).startswith('_')]
-    for plugin_path in sorted(plugin_dirs, reverse=True, key=lambda d: (ordered.index(d) if d in ordered else 0)):
+    for plugin_path in sorted(plugin_dirs, reverse=True, key=lambda d: (ordered.index(basename(d)) if basename(d) in ordered else -1)):
         sys.path.append(plugin_path)
         plugin_name = basename(plugin_path).replace('-', '_')
         plugins[plugin_name] = importlib.import_module(plugin_name)


### PR DESCRIPTION
In some cases, Sideboard was comparing a full path (e.g. '/home/vagrant/uber/sideboard/plugins/uber') with a plugin name (e.g. 'uber') to sort plugins. Doing so would break priority plugins settings. This now always uses the 'basename' of a directory, so you don't have to worry about its path.

Fixes https://github.com/magfest/sideboard/issues/13.