### PR TITLE
sort glob() output for consistent results

### DIFF
--- a/sideboard/internal/imports.py
+++ b/sideboard/internal/imports.py
@@ -8,9 +8,15 @@ from sideboard.config import config
 
 plugins = {}
 
+
 def _discover_plugins():
     ordered = list(reversed(config['priority_plugins']))
     plugin_dirs = [d for d in glob(join(config['plugins_dir'], '*')) if isdir(d) and not basename(d).startswith('_')]
+
+    # glob() results are not ordered, so we sort here to ensure non-prioritized plugins load in the same order
+    # regardless of OS-dependent arbitrary ordering
+    plugin_dirs = sorted(plugin_dirs, key=lambda d: basename(d))
+
     for plugin_path in sorted(plugin_dirs, reverse=True, key=lambda d: (ordered.index(basename(d)) if basename(d) in ordered else -1)):
         sys.path.append(plugin_path)
         plugin_name = basename(plugin_path).replace('-', '_')


### PR DESCRIPTION
Since glob() returns an ordering that is os-dependent, we need to sort here in order to ensure that all OS'es load the non-prioritized plugins in the same order

This change does not fix any loading issues, BUT it will ensure that if there IS a load order issue, it will happen either everywhere or nowhere.  This eliminates "why is it working on my machine but not on the server".

sidenote: Originally I wanted to do this change as a precaution, however, it turns out it's necessary for my computer and magstock staging server to load things in the same order.

### before fix:
non-prioritized plugin load order on magfest staging server:
```
['bands', 'barcode', 'magstock', 'uber_analytics']
```

non-prioritized plugin load order on my box:
```
['magstock', 'barcode', 'uber_analytics', 'bands']
```

### after fix: 

both environments now load in the same order:
```
['bands', 'barcode', 'magstock', 'uber_analytics']
```