### PR TITLE
Centralized logging - add multiline indent, remove syslog output by default

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -9,12 +9,3 @@ engine.autoreload.on = True
 
 [loggers]
 root = "DEBUG"
-
-[handlers]
-#[[stdout]]
-#class = "logging.StreamHandler"
-#stream = "ext://sys.stderr"
-
-[[syslog]]
-class = "logging.handlers.SysLogHandler"
-address = "/dev/log"

--- a/sideboard/internal/logging.py
+++ b/sideboard/internal/logging.py
@@ -7,12 +7,21 @@ import logging_unterpolation
 from sideboard.config import config
 
 
+class IndentMultilinesLogFormatter(logging.Formatter):
+    def format(self, record):
+        s = super(IndentMultilinesLogFormatter, self).format(record)
+        # indent all lines that start with a newline so they are easier for external log programs to parse
+        s = s.rstrip('\n').replace('\n','\n    ')
+        return s
+
+
 def _configure_logging():
     logging_unterpolation.patch_logging()
     fname='/etc/sideboard/logging.cfg'
     if os.path.exists(fname):
         logging.config.fileConfig(fname, disable_existing_loggers=True)
     else:
+        format_str = '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
         logging.config.dictConfig({
         'version': 1,
         'root': {
@@ -26,7 +35,11 @@ def _configure_logging():
         'handlers': config['handlers'].dict(),
         'formatters': {
             'default': {
-                'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
-            }
+                'format': format_str,
+            },
+            'indent_multiline': {
+                '()': IndentMultilinesLogFormatter,
+                'format': format_str,
+            },
         }
     })


### PR DESCRIPTION
2 things:
1) Add a formatter (which is off by default but can be switched on via INI) that takes any multiline output and indents it.  This makes it easier for external log tools to parse our output and keep stack traces (which output multiple lines) together as one logical unit.
2) By default we output to syslog via development-defaults.ini and downstream configuration can't switch this off.  Make it so we don't output to syslog by default so that puppet and other things can change this behavior later