### PR TITLE
turn up all logging thresholds to the highest levels

### DIFF
--- a/sideboard/configspec.ini
+++ b/sideboard/configspec.ini
@@ -57,10 +57,10 @@ ___many___ = string
 
 
 [loggers]
-root = option("DEBUG", "INFO", "WARN", "WARNING", "ERROR", "CRITICAL", default="INFO")
+root = option("DEBUG", "INFO", "WARN", "WARNING", "ERROR", "CRITICAL", default="DEBUG")
 cherrypy.error = option("DEBUG", "INFO", "WARNING", "WARN", "ERROR", "CRITICAL", default="DEBUG")
-cherrypy.access = option("DEBUG", "INFO", "WARNING", "WARN", "ERROR", "CRITICAL", default="CRITICAL")
-__many__ = option("DEBUG", "INFO", "WARN", "WARNING", "ERROR", "CRITICAL", default="INFO")
+cherrypy.access = option("DEBUG", "INFO", "WARNING", "WARN", "ERROR", "CRITICAL", default="DEBUG")
+__many__ = option("DEBUG", "INFO", "WARN", "WARNING", "ERROR", "CRITICAL", default="DEBUG")
 
 [handlers]
 [[__many__]]


### PR DESCRIPTION
- doesn't add much spam but does report which files are actually being served up, which is good data to collect

definitely want this on our servers in order to get the access logs, but also, I think it's a sensible default even if it adds a line for each access.