### PR TITLE
set thread names on startup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   - TOX_ENV=py34
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y libcap
+  - sudo apt-get install -y build-essential libcap-dev
 install:
   - pip install tox
   - pip install python-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ env:
   - TOX_ENV=py27
   - TOX_ENV=py33
   - TOX_ENV=py34
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libcap
 install:
   - pip install tox
   - pip install python-coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ paver==1.2.2
 wheel==0.24.0
 pip==1.5.6
 sh==1.09
+python-prctl==1.6.1

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,6 @@ requires = list(reversed(requires))
 if sys.version_info[0] == 2:
     requires = ['CherryPy==3.2.2' if 'cherrypy' in r.lower() else r for r in requires]
 
-# We use a Python3-only library to set thread names
-if sys.version_info[0] == 3:
-    requires.append('python-prctl==1.6.1')
-
 if __name__ == '__main__':
     setup(
         name=pkg_name,


### PR DESCRIPTION
- this code monkeypatches the start of each thread to call prctl() which sets the thread name
- this allows external utilities, like top and ps, to show thread names
- this is great because if a particular thread is going off the rails, we can now see which one using external tools
- requires build-package and libcap to be installed on the system

requires https://github.com/magfest/ubersystem-puppet/pull/110