### PR TITLE
implemented a read/write lock utility class in sideboard.lib

### DIFF
--- a/sideboard/lib/__init__.py
+++ b/sideboard/lib/__init__.py
@@ -4,7 +4,7 @@ import six
 
 from sideboard.internal.autolog import log
 from sideboard.config import config, ConfigurationError, parse_config
-from sideboard.lib._utils import is_listy, listify, serializer, cached_property, request_cached_property, class_property, entry_point
+from sideboard.lib._utils import is_listy, listify, serializer, cached_property, request_cached_property, class_property, entry_point, RWGuard
 from sideboard.lib._cp import stopped, on_startup, on_shutdown, mainloop, ajax, renders_template, render_with_templates
 from sideboard.lib._threads import DaemonTask, Caller, GenericCaller, TimeDelayQueue
 from sideboard.lib._websockets import WebSocket, Model, Subscription, MultiSubscription
@@ -18,7 +18,7 @@ __all__ = ['log',
            'stopped', 'on_startup', 'on_shutdown', 'mainloop', 'ajax', 'renders_template', 'render_with_templates',
            'DaemonTask', 'Caller', 'GenericCaller', 'TimeDelayQueue',
            'WebSocket', 'Model', 'Subscription', 'MultiSubscription',
-           'listify', 'serializer', 'cached_property', 'request_cached_property', 'is_listy', 'entry_point',
+           'listify', 'serializer', 'cached_property', 'request_cached_property', 'is_listy', 'entry_point', 'RWGuard',
            'threadlocal', 'subscribes', 'locally_subscribes', 'notifies', 'notify']
 if six.PY2:
     __all__ = [s.encode('ascii') for s in __all__]

--- a/sideboard/lib/_utils.py
+++ b/sideboard/lib/_utils.py
@@ -3,7 +3,9 @@ import os
 import json
 from functools import wraps
 from datetime import datetime, date
-from collections import Sized, Iterable, Mapping
+from contextlib import contextmanager
+from threading import RLock, Condition, current_thread
+from collections import Sized, Iterable, Mapping, defaultdict
 
 
 def is_listy(x):
@@ -146,3 +148,112 @@ def entry_point(func):
 
 _entry_points = {}
 
+
+class RWGuard(object):
+    """
+    This utility class provides the ability to perform read/write locking, such
+    that we can have any number of readers OR a single writer.  We give priority
+    to writers, who will get the lock before any readers.
+
+    These locks are reentrant, meaning that the same thread can acquire a read
+    or write lock multiple times, and will then need to release the lock the
+    same number of times it was acquired.  A thread with an acquired read lock
+    cannot acquire a write lock, or vice versa.  Locks can only be released by
+    the threads which acquired them.
+
+    This class is named RWGuard rather than RWLock because it is not itself a
+    lock, e.g. it doesn't have an acquire method, it cannot be directly used as
+    a context manager, etc.
+    """
+    def __init__(self):
+        self.lock = RLock()
+        self.waiting_writer_count = 0
+        self.acquired_writer = defaultdict(int)
+        self.acquired_readers = defaultdict(int)
+        self.ready_for_reads = Condition(self.lock)
+        self.ready_for_writes = Condition(self.lock)
+
+    @property
+    @contextmanager
+    def read_locked(self):
+        """
+        Context manager which acquires a read lock on entrance and releases it
+        on exit.  Any number of threads may acquire a read lock.
+        """
+        self.acquire_for_read()
+        try:
+            yield
+        finally:
+            self.release()
+
+    @property
+    @contextmanager
+    def write_locked(self):
+        """
+        Context manager which acquires a write lock on entrance and releases it
+        on exit.  Only one thread may acquire a write lock at a time.
+        """
+        self.acquire_for_write()
+        try:
+            yield
+        finally:
+            self.release()
+
+    def acquire_for_read(self):
+        """
+        NOTE: consumers are encouraged to use the "read_locked" context manager
+        instead of this method where possible.
+
+        This method acquires the read lock for the current thread, blocking if
+        necessary until there are no other threads with the write lock acquired
+        or waiting for the write lock to be available.
+        """
+        tid = current_thread().ident
+        assert tid not in self.acquired_writer, 'Threads which have already acquired a write lock may not lock for reading'
+        with self.lock:
+            while self.acquired_writer or (self.waiting_writer_count and tid not in self.acquired_readers):
+                self.ready_for_reads.wait()
+            self.acquired_readers[tid] += 1
+
+    def acquire_for_write(self):
+        """
+        NOTE: consumers are encouraged to use the "write_locked" context manager
+        instead of this method where possible.
+
+        This method acquires the write lock for the current thread, blocking if
+        necessary until no other threads have the write lock acquired and no
+        thread has the read lock acquired.
+        """
+        tid = current_thread().ident
+        assert tid not in self.acquired_readers, 'Threads which have already acquired a read lock may not lock for writing'
+        with self.lock:
+            while self.acquired_readers or (self.acquired_writer and tid not in self.acquired_writer):
+                self.waiting_writer_count += 1
+                self.ready_for_writes.wait()
+                self.waiting_writer_count -= 1
+            self.acquired_writer[tid] += 1
+
+    def release(self):
+        """
+        Release the read or write lock held by the current thread.  Since these
+        locks are reentrant, this method must be called once for each time the
+        lock was acquired.  This method raises an exception if called by a
+        thread with no read or write lock acquired.
+        """
+        tid = current_thread().ident
+        assert tid in self.acquired_readers or tid in self.acquired_writer, 'this thread does not hold a read or write lock'
+        with self.lock:
+            for counts in [self.acquired_readers, self.acquired_writer]:
+                counts[tid] -= 1
+                if counts[tid] <= 0:
+                    del counts[tid]
+
+            wake_readers = not self.waiting_writer_count
+            wake_writers = self.waiting_writer_count and not self.acquired_readers
+
+        if wake_writers:
+            with self.ready_for_writes:
+                self.ready_for_writes.notify()
+        elif wake_readers:
+            with self.ready_for_reads:
+                self.ready_for_reads.notify_all()


### PR DESCRIPTION
This feature has come up as something that would be useful both at my day job and in some of the MAGFest background tasks.

We want a lock with the following characteristics:
- any number of threads may acquire the lock in "read mode"
- only one thread may have the lock acquired in "write mode" at a time
- the locking modes are reentrant, i.e. the same thing can acquire the lock multiple times
- writes take precedence over reads, e.g. once a writer requests the lock, subsequent readers will block until the writer acquires and releases the lock

Locks are hard to write good unit tests for.  I did add several unit tests for this feature, including one which spins up other threads to ensure that the locking works as expected.  However, in order to REALLY test this out, I also wrote this script:
https://gist.github.com/EliAndrewC/2b23aa2bfb83b353abe5f64f0646c568

That script runs hundreds of threads at a time acquiring read and write locks.  I can see from the output that all of the properties explained above are proven out, e.g. I can see that
- many reader threads run at a time
- only one write thread runs at a time
- once a write thread requests the lock, readers start blocking even before it acquires the lock
- while the write thread is running, all readers block until it's done
- only one write thread has the lock at a time
- as soon as all write threads are finished, all of the readers which were blocking acquire the read lock and go to work

I ran this script for many hours to ensure that there were no unexpected edge cases causing it to jam up.  I also ensured that the CPU and memory usage was low to ensure that this implementation is efficient.