### PR TITLE
use new format for setup.cfg so pytest stops complaining

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [easy_install]
 zip_ok = False
 
-[pytest]
+[tool:pytest]
 norecursedirs = tests/plugins build env dist plugins/*/build plugins/*/env plugins/*/dist .tox
 python_files = test_*.py tests/__init__.py tests/*/__init__.py


### PR DESCRIPTION
apparently the old way is deprecated