### PR TITLE
Fix requirements txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cherrypy==3.6.0
 #python-ldap==2.3.13
 ws4py==0.3.2
 SQLAlchemy==1.0.0
-six==1.5.2
+six==1.10.0
 Jinja2==2.6
 rpctools==0.2.1
 logging_unterpolation==0.2.0
@@ -12,7 +12,7 @@ pytest==3.0.1
 mock==1.0.1
 Sphinx==1.2.1
 coverage==3.6
-paver==1.2.2
+paver==1.2.4
 wheel==0.24.0
 pip==1.5.6
 sh==1.09

--- a/sideboard/server.py
+++ b/sideboard/server.py
@@ -206,4 +206,4 @@ orig_mount = cherrypy.tree.mount
 cherrypy.tree.mount = mount
 cherrypy.tree.mount(Root(), '', app_config)
 
-del sys.modules['six.moves.winreg']  # kludgy workaround for CherryPy's autoreloader erroring on winreg
+# del sys.modules['six.moves.winreg']  # kludgy workaround for CherryPy's autoreloader erroring on winreg


### PR DESCRIPTION
And a line in server.py 

Been spending some personal time working on Sideboard, and found these issues. Helping some other devs get their setups going has shown me this PR might be needed. currently, without this PR install-unix.sh in simple-rams-deploy will fail on install_deps, leaving many a dev confused.
