### PR TITLE
added SIDEBOARD_CONFIG_ROOT environment variable

### DIFF
--- a/sideboard/config.py
+++ b/sideboard/config.py
@@ -18,8 +18,12 @@ def get_config_root():
     Returns the configuration root for the system, which defaults to '/etc/sideboard'.
     If the SIDEBOARD_CONFIG_ROOT environment variable is set, its contents will be returned instead.
     """
-    config_root = os.environ.get('SIDEBOARD_CONFIG_ROOT', '/etc/sideboard')
-    assert os.path.isdir(config_root) and os.access(config_root, os.R_OK), '{!r} directory is not readable'.format(config_root)
+    default_root = '/etc/sideboard'
+    config_root = os.environ.get('SIDEBOARD_CONFIG_ROOT', default_root)
+    if config_root != default_root and not os.path.isdir(config_root):
+        raise AssertionError('cannot find {!r} directory'.format(config_root))
+    elif os.path.isdir(config_root) and not os.access(config_root, os.R_OK):
+        raise AssertionError('{!r} directory is not readable'.format(config_root))
     return config_root
 
 

--- a/sideboard/internal/logging.py
+++ b/sideboard/internal/logging.py
@@ -4,7 +4,7 @@ import logging.config
 
 import logging_unterpolation
 
-from sideboard.config import config
+from sideboard.config import config, get_config_root
 
 
 class IndentMultilinesLogFormatter(logging.Formatter):
@@ -21,7 +21,7 @@ class IndentMultilinesLogFormatter(logging.Formatter):
 
 def _configure_logging():
     logging_unterpolation.patch_logging()
-    fname = '/etc/sideboard/logging.cfg'
+    fname = os.path.join(get_config_root(), 'logging.cfg')
     if os.path.exists(fname):
         logging.config.fileConfig(fname, disable_existing_loggers=True)
     else:


### PR DESCRIPTION
We implemented this locally to make it easier to run unit tests on different environments.  I accidentally neglected to push this up with my recent "resync back to the public repo" work.

This is relevant to https://github.com/magfest/sideboard/issues/66 which I'll comment on in a second to explain how it relates to what's been proposed there.