### PR TITLE
Adds custom unnamed CheckedConstraint naming convention to support Alembic migrations

### DIFF
--- a/sideboard/lib/sa/__init__.py
+++ b/sideboard/lib/sa/__init__.py
@@ -153,7 +153,7 @@ def check_constraint_naming_convention(constraint, table):
     If the generated name is longer than 32 characters, a uuid5 based on the
     generated name will be returned instead.
 
-    >>> check_constraint_naming_convention(CheckConstraint('failed_logins > 3'), Table('account'))
+    >>> check_constraint_naming_convention(CheckConstraint('failed_logins > 3'), Table('account', MetaData()))
     'failed_logins_gt_3'
 
     See: http://docs.sqlalchemy.org/en/latest/core/constraints.html#configuring-constraint-naming-conventions

--- a/sideboard/lib/sa/__init__.py
+++ b/sideboard/lib/sa/__init__.py
@@ -143,6 +143,37 @@ else:
     __all__.append('UTCDateTime')
 
 
+def check_constraint_naming_convention(constraint, table):
+    """Creates a unique name for an unnamed CheckConstraint.
+
+    The generated name is the SQL text of the CheckConstraint with
+    non-alphanumeric, non-underscore operators converted to text, and all
+    other non-alphanumeric, non-underscore substrings replaced by underscores.
+
+    >>> check_constraint_naming_convention(CheckConstraint('failed_logins > 3'), Table('account'))
+    'failed_logins_gt_3'
+
+    See: http://docs.sqlalchemy.org/en/latest/core/constraints.html#configuring-constraint-naming-conventions
+    """
+    # The text of the replacements doesn't matter, so long as it's unique
+    replacements = [
+        ('||/', 'cr'), ('<=', 'le'), ('>=', 'ge'), ('<>', 'nq'), ('!=', 'ne'),
+        ('||', 'ct'), ('<<', 'ls'), ('>>', 'rs'), ('!!', 'fa'), ('|/', 'sr'),
+        ('@>', 'cn'), ('<@', 'cb'), ('&&', 'an'), ('<', 'lt'), ('=', 'eq'),
+        ('>', 'gt'), ('!', 'ex'), ('"', 'qt'), ('#', 'hs'), ('$', 'dl'),
+        ('%', 'pc'), ('&', 'am'), ('\'', 'ap'), ('(', 'lpr'), (')', 'rpr'),
+        ('*', 'as'), ('+', 'pl'), (',', 'cm'), ('-', 'da'), ('.', 'pd'),
+        ('/', 'sl'), (':', 'co'), (';', 'sc'), ('?', 'qn'), ('@', 'at'),
+        ('[', 'lbk'), ('\\', 'bs'), (']', 'rbk'), ('^', 'ca'), ('`', 'tk'),
+        ('{', 'lbc'), ('|', 'pi'), ('}', 'rbc'), ('~', 'td')]
+
+    constraint_name = str(constraint.sqltext).strip()
+    for operator, text in replacements:
+        constraint_name = constraint_name.replace(operator, text)
+
+    return re.sub('[\W\s]+', '_', constraint_name)
+
+
 # SQLAlchemy doesn't expose its default constructor as a nicely importable
 # function, so we grab it from the function defaults.
 if six.PY2:

--- a/sideboard/lib/sa/__init__.py
+++ b/sideboard/lib/sa/__init__.py
@@ -150,6 +150,9 @@ def check_constraint_naming_convention(constraint, table):
     non-alphanumeric, non-underscore operators converted to text, and all
     other non-alphanumeric, non-underscore substrings replaced by underscores.
 
+    If the generated name is longer than 32 characters, a uuid5 based on the
+    generated name will be returned instead.
+
     >>> check_constraint_naming_convention(CheckConstraint('failed_logins > 3'), Table('account'))
     'failed_logins_gt_3'
 
@@ -171,7 +174,10 @@ def check_constraint_naming_convention(constraint, table):
     for operator, text in replacements:
         constraint_name = constraint_name.replace(operator, text)
 
-    return re.sub('[\W\s]+', '_', constraint_name)
+    constraint_name = re.sub('[\W\s]+', '_', constraint_name)
+    if len(constraint_name) > 32:
+        constraint_name = uuid.uuid5(uuid.NAMESPACE_OID, constraint_name).hex
+    return constraint_name
 
 
 # SQLAlchemy doesn't expose its default constructor as a nicely importable

--- a/sideboard/lib/sa/__init__.py
+++ b/sideboard/lib/sa/__init__.py
@@ -176,7 +176,7 @@ def check_constraint_naming_convention(constraint, table):
 
     constraint_name = re.sub('[\W\s]+', '_', constraint_name)
     if len(constraint_name) > 32:
-        constraint_name = uuid.uuid5(uuid.NAMESPACE_OID, constraint_name).hex
+        constraint_name = uuid.uuid5(uuid.NAMESPACE_OID, str(constraint_name)).hex
     return constraint_name
 
 

--- a/sideboard/tests/test_sa.py
+++ b/sideboard/tests/test_sa.py
@@ -206,7 +206,8 @@ class TestNamingConventions(object):
     @pytest.mark.parametrize('sqltext,expected', [
         ('failed_logins >= 3', 'failed_logins_ge_3'),
         ('failed_logins > 3', 'failed_logins_gt_3'),
-        ('   failed_logins   =   3'  , 'failed_logins_eq_3')
+        ('   failed_logins   =   3   '  , 'failed_logins_eq_3'),
+        ('0123456789012345678901234567890123', '1e4008bc148c5486a3c92b2377fa1c45')
     ])
     def test_check_constraint_naming_convention(self, sqltext, expected):
         check_constraint = CheckConstraint(sqltext)
@@ -232,7 +233,7 @@ class TestDeclarativeBaseConstructor(object):
 
         assert Foo().id is None
 
-    def test_declarative_base_without_parameters():
+    def test_declarative_base_without_parameters(self):
 
         @declarative_base
         class BaseTest:
@@ -240,7 +241,7 @@ class TestDeclarativeBaseConstructor(object):
 
         assert BaseTest.__tablename__ == 'base_test'
 
-    def test_declarative_base_with_parameters():
+    def test_declarative_base_with_parameters(self):
 
         @declarative_base(name=str('NameOverride'))
         class BaseTest:

--- a/sideboard/tests/test_sa.py
+++ b/sideboard/tests/test_sa.py
@@ -9,31 +9,14 @@ import sqlalchemy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.types import Boolean, Integer, UnicodeText
-from sqlalchemy.schema import Column, ForeignKey, UniqueConstraint
+from sqlalchemy.schema import Column, CheckConstraint, ForeignKey, MetaData, Table, UniqueConstraint
 from sqlalchemy.sql import case
 
 from sideboard.lib import log, listify
 from sideboard.tests import patch_session
 from sideboard.lib.sa._crud import normalize_query, collect_ancestor_classes
-from sideboard.lib.sa import SessionManager, UUID, JSON, declarative_base, CrudException, crudable, text_length_validation, regex_validation
-
-
-def test_declarative_base_without_parameters():
-
-    @declarative_base
-    class BaseTest:
-        pass
-
-    assert BaseTest.__tablename__ == 'base_test'
-
-
-def test_declarative_base_with_parameters():
-
-    @declarative_base(name=str('NameOverride'))
-    class BaseTest:
-        pass
-
-    assert BaseTest.__tablename__ == 'name_override'
+from sideboard.lib.sa import check_constraint_naming_convention, crudable, declarative_base, \
+    regex_validation, text_length_validation, CrudException, JSON, SessionManager, UUID
 
 
 @declarative_base
@@ -218,6 +201,20 @@ def db(request, init_db):
     return init_db
 
 
+class TestNamingConventions(object):
+
+    @pytest.mark.parametrize('sqltext,expected', [
+        ('failed_logins >= 3', 'failed_logins_ge_3'),
+        ('failed_logins > 3', 'failed_logins_gt_3'),
+        ('   failed_logins   =   3'  , 'failed_logins_eq_3')
+    ])
+    def test_check_constraint_naming_convention(self, sqltext, expected):
+        check_constraint = CheckConstraint(sqltext)
+        table = Table('account', MetaData())
+        result = check_constraint_naming_convention(check_constraint, table)
+        assert result == expected
+
+
 class TestDeclarativeBaseConstructor(object):
     def test_default_init(self):
         assert User().id  # default is applied at initialization instead of on save
@@ -234,6 +231,22 @@ class TestDeclarativeBaseConstructor(object):
             bar = Column(Boolean())
 
         assert Foo().id is None
+
+    def test_declarative_base_without_parameters():
+
+        @declarative_base
+        class BaseTest:
+            pass
+
+        assert BaseTest.__tablename__ == 'base_test'
+
+    def test_declarative_base_with_parameters():
+
+        @declarative_base(name=str('NameOverride'))
+        class BaseTest:
+            pass
+
+        assert BaseTest.__tablename__ == 'name_override'
 
 
 class TestCrudCount(object):

--- a/sideboard/tests/test_sa.py
+++ b/sideboard/tests/test_sa.py
@@ -206,7 +206,7 @@ class TestNamingConventions(object):
     @pytest.mark.parametrize('sqltext,expected', [
         ('failed_logins >= 3', 'failed_logins_ge_3'),
         ('failed_logins > 3', 'failed_logins_gt_3'),
-        ('   failed_logins   =   3   '  , 'failed_logins_eq_3'),
+        ('   failed_logins   =   3   ', 'failed_logins_eq_3'),
         ('0123456789012345678901234567890123', '1e4008bc148c5486a3c92b2377fa1c45')
     ])
     def test_check_constraint_naming_convention(self, sqltext, expected):


### PR DESCRIPTION
If you have any unnamed ~constraints – even non CheckConstraints –~ unnamed CheckConstraints SQLAlchemy will complain if you try to use the `%(constraint_name)s` token in MetaData.naming_conventions. So, instead of using `%(constraint_name)s` as suggested [in the docs](http://docs.sqlalchemy.org/en/latest/core/constraints.html#constraint-naming-conventions), I'm adding a custom function that converts the CheckConstraint.sqltext to a valid name.

It's not used anywhere in sideboard directly, but it's a generally useful function that many plugins can use.