### PR TITLE
Preserves plugin import order using OrderedDict

### DIFF
--- a/sideboard/internal/imports.py
+++ b/sideboard/internal/imports.py
@@ -1,23 +1,32 @@
 from __future__ import unicode_literals
 import sys
 import importlib
+from collections import OrderedDict
 from glob import glob
+from itertools import chain
 from os.path import join, isdir, basename
 
 from sideboard.config import config
 
-plugins = {}
+
+plugins = OrderedDict()
+plugin_dirs = OrderedDict()
+
+
+def _discover_plugin_dirs():
+    unsorted_dirs = {basename(d).replace('-', '_'): d
+            for d in glob(join(config['plugins_dir'], '*'))
+            if isdir(d) and not basename(d).startswith('_')}
+
+    priority_plugins = config['priority_plugins']
+    nonpriority_plugins = sorted(set(unsorted_dirs.keys()).difference(priority_plugins))
+    sorted_plugins = chain(priority_plugins, nonpriority_plugins)
+
+    return [(name, unsorted_dirs[name]) for name in sorted_plugins]
 
 
 def _discover_plugins():
-    ordered = list(reversed(config['priority_plugins']))
-    plugin_dirs = [d for d in glob(join(config['plugins_dir'], '*')) if isdir(d) and not basename(d).startswith('_')]
-
-    # glob() results are not ordered, so we sort here to ensure non-prioritized plugins load in the same order
-    # regardless of OS-dependent arbitrary ordering
-    plugin_dirs = sorted(plugin_dirs, key=lambda d: basename(d))
-
-    for plugin_path in sorted(plugin_dirs, reverse=True, key=lambda d: (ordered.index(basename(d)) if basename(d) in ordered else -1)):
-        sys.path.append(plugin_path)
-        plugin_name = basename(plugin_path).replace('-', '_')
-        plugins[plugin_name] = importlib.import_module(plugin_name)
+    for name, path in _discover_plugin_dirs():
+        sys.path.append(path)
+        plugins[name] = importlib.import_module(name)
+        plugin_dirs[name] = path

--- a/sideboard/tests/test_imports.py
+++ b/sideboard/tests/test_imports.py
@@ -1,0 +1,26 @@
+import os
+import shutil
+import tempfile
+from os.path import join
+
+import pytest
+
+from sideboard.config import config
+from sideboard.internal.imports import _discover_plugin_dirs
+
+
+class TestDiscoverPluginDirs:
+
+    def test_discover_plugin_dirs(self, monkeypatch):
+        plugins_dir = tempfile.mkdtemp()
+        try:
+            monkeypatch.setitem(config, 'plugins_dir', plugins_dir)
+            plugin_names = ['_u', 'a', 'z', 'b', 'y', 'c', 'x']
+            plugin_dirs = {name: join(plugins_dir, name) for name in plugin_names}
+            for plugin_name, plugin_dir in plugin_dirs.items():
+                os.makedirs(plugin_dir)
+            actual = _discover_plugin_dirs()
+            expected = [(name, plugin_dirs[name]) for name in sorted(plugin_names) if name != '_u']
+            assert actual == expected
+        finally:
+            shutil.rmtree(plugins_dir, ignore_errors=True)

--- a/sideboard/tests/test_imports.py
+++ b/sideboard/tests/test_imports.py
@@ -15,12 +15,12 @@ class TestDiscoverPluginDirs:
         plugins_dir = tempfile.mkdtemp()
         try:
             monkeypatch.setitem(config, 'plugins_dir', plugins_dir)
-            plugin_names = ['_u', 'a', 'z', 'b', 'y', 'c', 'x']
+            plugin_names = ['_u', 'a-1', 'z-2', 'b_3', 'y_4', 'c-6', 'x_7']
             plugin_dirs = {name: join(plugins_dir, name) for name in plugin_names}
             for plugin_name, plugin_dir in plugin_dirs.items():
                 os.makedirs(plugin_dir)
             actual = _discover_plugin_dirs()
-            expected = [(name, plugin_dirs[name]) for name in sorted(plugin_names) if name != '_u']
+            expected = [(name.replace('-', '_'), plugin_dirs[name]) for name in sorted(plugin_names) if name != '_u']
             assert actual == expected
         finally:
             shutil.rmtree(plugins_dir, ignore_errors=True)


### PR DESCRIPTION
The plugin import order will be useful for generating/running DB migrations. Plus it's just a generally useful thing to have around. The heart of this pull request was swapping `plugins = {}` with `plugins = OrderedDict()`, but I did some additional code refactoring to make it easier to test.

I'll add some review comments explaining my thinking.