### PR TITLE
Populates plugin_dirs before importing plugins

### DIFF
--- a/sideboard/internal/imports.py
+++ b/sideboard/internal/imports.py
@@ -28,5 +28,7 @@ def _discover_plugin_dirs():
 def _discover_plugins():
     for name, path in _discover_plugin_dirs():
         sys.path.append(path)
-        plugins[name] = importlib.import_module(name)
         plugin_dirs[name] = path
+
+    for name, path in plugin_dirs:
+        plugins[name] = importlib.import_module(name)


### PR DESCRIPTION
Populates plugin_dirs before importing plugins, so it will be available to plugins that depend on plugin_dirs. Also, it just seems like a good idea to separate these.