### PR TITLE
Adding missing unicode_literals imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_install:
   - sudo apt-get install -y build-essential libcap-dev
 install:
   - pip install tox
-  - pip install -r test_requirements.txt
   - if [[ $TOX_ENV == py27 ]] || [[ $TOX_ENV == py35 ]]; then
       pip install coveralls;
     fi

--- a/sideboard/lib/_profiler.py
+++ b/sideboard/lib/_profiler.py
@@ -46,6 +46,7 @@ configspec.ini for more details::
     profiling.strip_dirs = False
 
 """
+from __future__ import unicode_literals
 import io
 import os
 import os.path

--- a/sideboard/tests/test_imports.py
+++ b/sideboard/tests/test_imports.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os
 import shutil
 import tempfile

--- a/sideboard/tests/test_profiler.py
+++ b/sideboard/tests/test_profiler.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from sideboard.lib import cleanup_profiler, profile
 from sideboard.config import config
 


### PR DESCRIPTION
MAGFest uses Python 3 and so doesn't care about ``from __future__ import unicode_literals`` but at my day job we still use Python 2.7 for a couple of legacy codebases and so we have our local builds check for the presence of that line in every Python file in the Sideboard codebase.  I've added it in to a few new files where it was missing; I didn't think to check for it when I was reviewing those files since all of my new projects have been on Python 3 for some time.

I also removed the unnecessary Travis line we discussed in the other PR.