### PR TITLE
Fixes #56: Removes upper bounds on cherrypy version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 configobj>=5.0.5
-cherrypy>=3.6.0,<9.0
+cherrypy>=3.6.0
 ws4py>=0.3.2
 SQLAlchemy>=1.1.0
 six>=1.5.2


### PR DESCRIPTION
Fixes #56. Looks like everything works on the latest version of cherrypy. The tests are passing and uber seems to be working fine (although we still have [this unrelated intermittent problem](https://github.com/magfest/sideboard/issues/76)).

