### PR TITLE
Changes name used for cached property to avoid collisions with common naming pattern

### DIFF
--- a/sideboard/lib/_utils.py
+++ b/sideboard/lib/_utils.py
@@ -73,7 +73,7 @@ serializer.register(set, lambda s: sorted(list(s)))
 
 def cached_property(func):
     """decorator for making readonly, memoized properties"""
-    pname = "_" + func.__name__
+    pname = '_cached_{}'.format(func.__name__)
 
     @property
     @wraps(func)

--- a/sideboard/tests/test_lib.py
+++ b/sideboard/tests/test_lib.py
@@ -463,10 +463,10 @@ def test_cached_property():
             return 5
 
     foo = Foo()
-    assert not hasattr(foo, '_bar')
+    assert not hasattr(foo, '_cached_bar')
     assert 5 == foo.bar
-    assert 5 == foo._bar
-    foo._bar = 6
+    assert 5 == foo._cached_bar
+    foo._cached_bar = 6
     assert 6 == foo.bar
     assert 5 == Foo().bar  # per-instance caching
 


### PR DESCRIPTION
It's a very common convention in the python world to use `property_name` for a "public" property and `_property_name` for a "private" attribute. That's probably why this naming convention was chosen for `@cached_property` in the first place.

However, because it's so common, it's not unreasonable to expect collisions to happen when an unsuspecting programmer expects to be able to use both names.