### PR TITLE
turn on cherrypy access logging for stdout

### DIFF
--- a/sideboard/configspec.ini
+++ b/sideboard/configspec.ini
@@ -142,7 +142,7 @@ jsonrpc_only = boolean(default=False)
 [loggers]
 root = option("TRACE", "DEBUG", "INFO", "WARN", "WARNING", "ERROR", "CRITICAL", default="DEBUG")
 cherrypy.error = option("TRACE", "DEBUG", "INFO", "WARNING", "WARN", "ERROR", "CRITICAL", default="DEBUG")
-cherrypy.access = option("TRACE", "DEBUG", "INFO", "WARNING", "WARN", "ERROR", "CRITICAL", default="CRITICAL")
+cherrypy.access = option("TRACE", "DEBUG", "INFO", "WARNING", "WARN", "ERROR", "CRITICAL", default="DEBUG")
 __many__ = option("TRACE", "DEBUG", "INFO", "WARN", "WARNING", "ERROR", "CRITICAL", default="INFO")
 
 [handlers]


### PR DESCRIPTION
Shows HTTP requests in the logs with IPs, which is super-useful though verbose

This does clutter up things a bit for debugging/local stuff but is super-useful in production.  If that is an issue, we could enable it via magfest's puppet scripts to only turn on for non-vagrant servers

@EliAndrewC may have feels on this as far as it being the default in upstream sideboard