### PR TITLE
Makes jsonrpc_handler more flexible

### DIFF
--- a/sideboard/internal/autolog.py
+++ b/sideboard/internal/autolog.py
@@ -187,8 +187,9 @@ class AutoLogger(object):
         self.adapter_kwargs = adapter_kwargs
 
     def __getattr__(self, name):
-        if 'self' in inspect.currentframe().f_back.f_locals:
-            other = inspect.currentframe().f_back.f_locals['self']
+        f_locals = inspect.currentframe().f_back.f_locals
+        if 'self' in f_locals and f_locals['self'] is not None:
+            other = f_locals['self']
             caller_name = '%s.%s' % (other.__class__.__module__, other.__class__.__name__)
         else:
             caller_name = inspect.currentframe().f_back.f_globals['__name__']

--- a/sideboard/jsonrpc.py
+++ b/sideboard/jsonrpc.py
@@ -44,7 +44,7 @@ def _make_jsonrpc_handler(services, debug=config['debug'],
     @cherrypy.expose
     @cherrypy.tools.force_json_in()
     @cherrypy.tools.json_out(handler=json_handler)
-    def jsonrpc_handler(self):
+    def jsonrpc_handler(self=None):
         id = None
 
         def error(code, message):

--- a/sideboard/jsonrpc.py
+++ b/sideboard/jsonrpc.py
@@ -44,7 +44,7 @@ def _make_jsonrpc_handler(services, debug=config['debug'],
     @cherrypy.expose
     @cherrypy.tools.force_json_in()
     @cherrypy.tools.json_out(handler=json_handler)
-    def jsonrpc_handler(self):
+    def jsonrpc_handler(*args):
         id = None
 
         def error(code, message):

--- a/sideboard/jsonrpc.py
+++ b/sideboard/jsonrpc.py
@@ -44,7 +44,7 @@ def _make_jsonrpc_handler(services, debug=config['debug'],
     @cherrypy.expose
     @cherrypy.tools.force_json_in()
     @cherrypy.tools.json_out(handler=json_handler)
-    def jsonrpc_handler(*args):
+    def jsonrpc_handler(self=None):
         id = None
 
         def error(code, message):

--- a/sideboard/jsonrpc.py
+++ b/sideboard/jsonrpc.py
@@ -44,7 +44,7 @@ def _make_jsonrpc_handler(services, debug=config['debug'],
     @cherrypy.expose
     @cherrypy.tools.force_json_in()
     @cherrypy.tools.json_out(handler=json_handler)
-    def jsonrpc_handler(self=None):
+    def jsonrpc_handler(self):
         id = None
 
         def error(code, message):


### PR DESCRIPTION
The `jsonrpc_handler` was created with the intent that it would be added as a member of a class, so it was given a single positional parameter named `self`.  This unfortunately breaks when the `jsonrpc_handler` is used outside the context of a class (it throws "missing required `self` argument" errors).

The `self` parameter is never actually referenced. This pull request switches the parameter from `self` to `self=None`, so the `jsonrpc_handler` function can be invoked outside the context of a class.