### PR TITLE
add psutil and prctl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ paver>=1.2.2
 wheel>=0.24.0
 pip>=1.5.6
 sh>=1.09
+python-prctl>=1.6.1
+psutil>=5.4.1


### PR DESCRIPTION
looks like these were left off in a merge error, adding them back in

fixes #90 

I BELIEVE this was just a merge error but @EliAndrewC  and @RobRuana if you know of any reason why these shouldn't be here, let me know.

It's super-useful to see the thread names in htop when diagnosing CPU issues on production servers, and in the future once we have multiple processes going.