### PR TITLE
Adds basic support for pip environment markers to setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ paver>=1.2.2
 wheel>=0.24.0
 pip>=1.5.6
 sh>=1.09
-python-prctl>=1.6.1
+python-prctl>=1.6.1; 'linux' in sys_platform
 psutil>=5.4.1

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,11 @@ with open(os.path.join(__here__, pkg_name, '_version.py')) as version:
 # __version__ is now defined
 req_data = open(os.path.join(__here__, 'requirements.txt')).read()
 raw_requires = [r.strip() for r in req_data.split() if r.strip() != '']
-raw_requires = list(reversed(raw_requires))
 
 # Ugly hack to reconcile pip requirements.txt and setup.py install_requires
 sys_platform = sys.platform
 requires = []
-for s in raw_requires:
+for s in reversed(raw_requires):
     if ';' in s:
         req, env_marker = s.split(';')
         if eval(env_marker):

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,19 @@ with open(os.path.join(__here__, pkg_name, '_version.py')) as version:
     exec(version.read())
 # __version__ is now defined
 req_data = open(os.path.join(__here__, 'requirements.txt')).read()
-requires = [r.strip() for r in req_data.split() if r.strip() != '']
-requires = list(reversed(requires))
+raw_requires = [r.strip() for r in req_data.split() if r.strip() != '']
+raw_requires = list(reversed(raw_requires))
+
+# Ugly hack to reconcile pip requirements.txt and setup.py install_requires
+sys_platform = sys.platform
+requires = []
+for s in raw_requires:
+    if ';' in s:
+        req, env_marker = s.split(';')
+        if eval(env_marker):
+            requires.append(s)
+    else:
+        requires.append(s)
 
 # testing dependencies
 req_data = open(os.path.join(__here__, 'test_requirements.txt')).read()


### PR DESCRIPTION
Turns out, the `python-prctl` is only supported on linux.

Fortunately, `pip` supports super cool [Environment Markers](https://www.python.org/dev/peps/pep-0496/) in `requirements.txt` files!
```
python-prctl>=1.6.1; 'linux' in sys_platform
```

Unfortunately, `setup.py` `install_requires` does NOT understand Environment Markers :cry:

So I did a bad thing. I made an ugly hack to add basic Environment Marker support to our `setup.py`.