### PR TITLE
Adds support for plugin.on_load() to plugin lifecycle.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -970,6 +970,8 @@ One of the most common things our web applications want to do is run tasks in th
 
 When we refer to "Sideboard starting" and "Sideboard stopping" we are referring specifically to when Sideboard starts its CherryPy server; this happens after all plugins have been imported, so you can safely call into other plugins in these tasks and functions.
 
+If instead of running a function when Sideboard starts, you need to run a function immediately after Sideboard loads a plugin, you may optionally declare an ``on_load()`` function in your plugin's top-level ``__init__.py`` module. If it exists, Sideboard will call ``on_load()`` immediately after loading the plugin, before attempting to load any subsequent plugins.
+
 
 .. function:: on_startup(func[, priority=50])
     

--- a/sideboard/internal/imports.py
+++ b/sideboard/internal/imports.py
@@ -3,6 +3,7 @@ import sys
 import importlib
 from collections import OrderedDict
 from glob import glob
+from itertools import chain
 from os.path import join, isdir, basename
 
 from sideboard.config import config
@@ -19,7 +20,7 @@ def _discover_plugin_dirs():
 
     priority_plugins = config['priority_plugins']
     nonpriority_plugins = sorted(set(unsorted_dirs.keys()).difference(priority_plugins))
-    sorted_plugins = priority_plugins + nonpriority_plugins
+    sorted_plugins = chain(priority_plugins, nonpriority_plugins)
 
     return [(name, unsorted_dirs[name]) for name in sorted_plugins]
 

--- a/sideboard/internal/imports.py
+++ b/sideboard/internal/imports.py
@@ -3,7 +3,6 @@ import sys
 import importlib
 from collections import OrderedDict
 from glob import glob
-from itertools import chain
 from os.path import join, isdir, basename
 
 from sideboard.config import config
@@ -20,7 +19,7 @@ def _discover_plugin_dirs():
 
     priority_plugins = config['priority_plugins']
     nonpriority_plugins = sorted(set(unsorted_dirs.keys()).difference(priority_plugins))
-    sorted_plugins = chain(priority_plugins, nonpriority_plugins)
+    sorted_plugins = priority_plugins + nonpriority_plugins
 
     return [(name, unsorted_dirs[name]) for name in sorted_plugins]
 
@@ -32,3 +31,5 @@ def _discover_plugins():
 
     for name, path in plugin_dirs.items():
         plugins[name] = importlib.import_module(name)
+        if callable(getattr(plugins[name], 'on_load', None)):
+            plugins[name].on_load()

--- a/sideboard/lib/_cp.py
+++ b/sideboard/lib/_cp.py
@@ -48,6 +48,13 @@ def on_startup(func=None, priority=50):
         @on_startup(priority=25)
         def callback_function():
             ...
+
+    If instead of running a function when Sideboard starts, you need to run a
+    function immediately after Sideboard loads your plugin, you may optionally
+    declare an on_load() function in your plugin's top-level __init__.py
+    module. If it exists, Sideboard will call on_load() immediately after
+    loading the plugin, before attempting to load any subsequent plugins.
+
     """
     if func:
         return _on_startup(func, priority)


### PR DESCRIPTION
# The Issue

When trying to use celery to run tasks from a plugin (or any other non `sep` script), we encounter an import sequence that causes subsequent plugins to load _before_ the initial plugin is fully loaded. This causes errors if the subsequent plugins have dependencies on the initial plugin.

For example, consider the case where we have two plugins: `alpha` and `omega`, where `omega` depends on `alpha`. The top-level modules for each look like this:

```python
# alpha/__init__.py

import sideboard
from alpha import config
from alpha import models
from alpha import site_sections
from alpha import tasks
```

```python
# omega/__init__.py

from alpha import config
config.function_we_expect_to_exist()
```

The following sequence will occur when we try to run `celery -A alpha.tasks worker`:
1. `alpha` starts being imported
2. Before `alpha` is finished being imported (before we hit the line `from alpha import config`), `sideboard` is imported
3. `sideboard` attempts to load its plugins in order (`alpha` then `omega`)
4. The `alpha` module already exists and is in the process of being imported, so no further action is taken when `sideboard` attempts to dynamically import it
5. The `omega` plugin is loaded
6. When the `omega` module attempts to import `config` from `alpha`, it will not exist yet, because the `alpha` module never got a chance to finish loading

As an aside, this is one of the major problems caused by import side-effects, and a good reason why they should be avoided.

# Potential Solution # 1

We could try to rearrange the order in which we import modules in `alpha/__init__.py`, in an attempt to load everything needed by `omega` before importing `sideboard`. However, virtually every submodule in `alpha` also depends on `sideboard`, so `sideboard` will invariably be imported by some submodule.

```python
# alpha/__init__.py

from alpha import config  # One of these modules probably imports sideboard
from alpha import models
from alpha import site_sections
from alpha import tasks

import sideboard  # Try moving it down here?
```

# Potential Solution # 2

We could try removing all import side-effects from `sideboard` itself. Instead of loading plugins as soon as `sideboard` is imported, we could have a top level `sideboard.initialize()` function (or something similar).

The major problem with this approach is that it would have a lot of knock-on effects, potentially creating a lot of additional work for other projects currently using `sideboard`.

# Potential Solution # 3 (this pull request)

The easiest solution would be to add an additional `on_load` step to the plugin lifecycle. When `sideboard` loads a plugin, it can check if an `on_load()` function exists on the top level module. Plugins can then use the `on_load()` function to completely configure themselves before `sideboard` attempts to load any subsequent plugins.

Under this implementation, `alpha/__init__.py` would look like this:
```python
# alpha/__init__.py

def on_load():
    from alpha import config
    from alpha import models
    from alpha import site_sections
    from alpha import tasks

import sideboard
```

With this configuration, `alpha.on_load()` is called and `alpha` will be fully configured before `omega` is ever loaded.

I have tested this locally, and it seems to be working with no further modifications to any other plugin code.