### PR TITLE
Adds support for redis based sessions

### DIFF
--- a/sideboard/lib/_cp.py
+++ b/sideboard/lib/_cp.py
@@ -9,6 +9,13 @@ from six.moves.urllib_parse import quote
 import jinja2
 import cherrypy
 
+try:
+    import cherrys
+    cherrypy.lib.sessions.RedisSession = cherrys.RedisSession
+except ImportError:
+    # cherrys not installed, so redis sessions not supported
+    pass
+
 import sideboard.lib
 from sideboard.lib import log, config, serializer
 


### PR DESCRIPTION
*Note:* this does NOT require `redis` or `cherrys`, but it will use them if they are available. If a plugin wants to use redis based sessions, it's the plugin's responsibility to ensure `cherrys` is installed.