### PR TITLE
pinned cherrypy to version 17.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 configobj>=5.0.5
-cherrypy>=3.6.0
+cherrypy==17.3.0
 ws4py>=0.3.2
 SQLAlchemy>=1.1.0
 six>=1.5.2


### PR DESCRIPTION
Later versions of cherrypy have some backwards-incompatible changes which prevent Sideboard from working.  In the long run we should pin to a later version or above and fix these import incompatibilities, but for now we pin to this version to prevent the issue.