### PR TITLE
Upgrade Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4.5
+FROM python:3.6.14
 MAINTAINER RAMS Project "code@magfest.org"
 LABEL version.sideboard ="1.0"
 WORKDIR /app


### PR DESCRIPTION
The version of Pillow we use requires at least Python 3.6.