### PR TITLE
Drop usage of cherrys library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ paver>=1.2.2
 pip>=1.5.6
 psutil>=5.4.1
 python-prctl>=1.6.1; 'linux' in sys_platform
-redis==4.6.0
+redis==4.3.6
 requests>=2.2.1
 rpctools>=0.3.1
 sh>=1.09

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,16 @@
-configobj>=5.0.5
 cherrypy==17.3.0
-ws4py>=0.3.2
-SQLAlchemy>=1.1.0
-six>=1.5.2
+configobj>=5.0.5
 Jinja2>=2.7
-rpctools>=0.3.1
 logging_unterpolation>=0.2.0
-requests>=2.2.1
 paver>=1.2.2
-wheel>=0.24.0
 pip>=1.5.6
-sh>=1.09
-python-prctl>=1.6.1; 'linux' in sys_platform
 psutil>=5.4.1
+python-prctl>=1.6.1; 'linux' in sys_platform
+redis==4.6.0
+requests>=2.2.1
+rpctools>=0.3.1
+sh>=1.09
+six>=1.5.2
+SQLAlchemy>=1.1.0
+wheel>=0.24.0
+ws4py>=0.3.2

--- a/sideboard/lib/_cp.py
+++ b/sideboard/lib/_cp.py
@@ -9,12 +9,8 @@ from six.moves.urllib_parse import quote
 import jinja2
 import cherrypy
 
-try:
-    import cherrys
-    cherrypy.lib.sessions.RedisSession = cherrys.RedisSession
-except ImportError:
-    # cherrys not installed, so redis sessions not supported
-    pass
+from sideboard.lib._redissession import RedisSession
+cherrypy.lib.sessions.RedisSession = RedisSession
 
 import sideboard.lib
 from sideboard.lib import log, config, serializer

--- a/sideboard/lib/_redissession.py
+++ b/sideboard/lib/_redissession.py
@@ -1,0 +1,88 @@
+import threading
+
+try:
+  import cPickle as pickle
+except ImportError:
+  import pickle
+
+from cherrypy.lib.sessions import Session
+import redis
+from redis import Sentinel
+
+class RedisSession(Session):
+
+    # the default settings
+    host = '127.0.0.1'
+    port = 6379
+    db = 0
+    password = None
+    tls_skip_verify = False
+    is_sentinel = False
+    ssl = False
+    user = ""
+
+
+    @classmethod
+    def setup(cls, **kwargs):
+        """Set up the storage system for redis-based sessions.
+        Called once when the built-in tool calls sessions.init.
+        """
+        # overwritting default settings with the config dictionary values
+        for k, v in kwargs.items():
+            setattr(cls, k, v)
+
+        if cls.tls_skip_verify:
+            cls.ssl_cert_req=None
+        else:
+            cls.ssl_cert_req="required"
+
+        if cls.is_sentinel:
+            sentinel = Sentinel([(cls.host, cls.port)], ssl=cls.ssl, ssl_cert_reqs=cls.ssl_cert_req, sentinel_kwargs={"password":cls.sentinel_pass, "ssl": cls.ssl, "ssl_cert_reqs": cls.ssl_cert_req}, username=cls.user, password=cls.password)
+            cls.cache = sentinel.master_for(cls.sentinel_service)
+            
+        else:
+            cls.cache = redis.Redis(
+                host=cls.host,
+                port=cls.port,
+                db=cls.db,
+                ssl=cls.ssl,
+                username=cls.user,
+                password=cls.password)
+
+    def _exists(self):
+        return bool(self.cache.exists(self.prefix+self.id))
+
+    def _load(self):
+        try:
+          return pickle.loads(self.cache.get(self.prefix+self.id))
+        except TypeError:
+          # if id not defined pickle can't load None and raise TypeError
+          return None
+
+    def _save(self, expiration_time):
+        pickled_data = pickle.dumps(
+            (self._data, expiration_time),
+            pickle.HIGHEST_PROTOCOL)
+
+        result = self.cache.setex(self.prefix+self.id, self.timeout * 60, pickled_data)
+
+        if not result:
+            raise AssertionError("Session data for id %r not set." % self.prefix+self.id)
+
+    def _delete(self):
+        self.cache.delete(self.prefix+self.id)
+
+    # http://docs.cherrypy.org/dev/refman/lib/sessions.html?highlight=session#locking-sessions
+    # session id locks as done in RamSession
+
+    locks = {}
+
+    def acquire_lock(self):
+        """Acquire an exclusive lock on the currently-loaded session data."""
+        self.locked = True
+        self.locks.setdefault(self.prefix+self.id, threading.RLock()).acquire()
+
+    def release_lock(self):
+        """Release the lock on the currently-loaded session data."""
+        self.locks[self.prefix+self.id].release()
+        self.locked = False


### PR DESCRIPTION
There's no version of cherrys that supports our combination of redis+cherrypy, and it's trivial to fork. This pulls it in directly and fixes a couple bugs.